### PR TITLE
[WIP] Comment decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.2 - July 10, 2019
+
+- Comment decoration (#14 by @PEZ)
+
 # 0.2.1 - July 4, 2019
 
 - Removed `configurationDefault` as it was conflicting with Calva (#13)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Jump to matching bracket commands:
 | `"clojureWarrior.cycleBracketColors"` | Whether same colors should be reused for deeply nested brackets | `true` |
 | `"clojureWarrior.misplacedBracketStyle"` | Style of misplaced bracket | `{ "border": "2px solid #c33" }` |
 | `"clojureWarrior.matchedBracketStyle"` | Style of bracket pair highlight | `{"backgroundColor": "#E0E0E0"}` |
+| `"clojureWarrior.commentFormStyle"` | Style of `(comment ...)` form | `{"textDecoration": "none; opacity: 0.5"}` |
+| `"clojureWarrior.ignoredFormStyle"` | Style of `#_...` form | `{"textDecoration": "none; opacity: 0.5"}` |
 
 To disable VS Code default bracket matching for Clojure files, add this to `settings.json`:
 
@@ -51,6 +53,28 @@ To disable VS Code default bracket matching for Clojure files, add this to `sett
 3. Install
 4. Restart Visual Studio Code (or click `Reload window`)
 5. Open a Clojure/ClojureScript/EDN file
+
+## Workign on Clojure Warrior
+
+Compiling:
+
+```
+cd clojure-warrior
+npm install
+npm run watch
+```
+
+Installing dev version locally:
+
+```
+ln -s `pwd` ~/.vscode/extensions/tonsky.clojure-warrior-0.2.0
+```
+
+Publishing:
+
+```
+vsce publish
+```
 
 ## License
 

--- a/extras/test.clj
+++ b/extras/test.clj
@@ -36,9 +36,19 @@
 
 (comment
   (comment (foo bar)))
-{:foo (comment (fn [x]
-                 (let [foo :bar])
-                 (str foo)))}
+(defn foo
+  (let [x "y"]
+    {:foo "bar"
+     :bar (comment (fn [x]
+                     (let [foo :bar])
+                     (str foo)))
+     :baz x}))
+(comment
+  (foo 2)
+  (Math/abs -1)
+  (range 10)
+  (println "I ❤️Clojure")
+  ([{} () []]))
 [comment]
 (foo) comment (bar)
 "(comment foo)"
@@ -51,7 +61,7 @@ foo(comment)bar
   (range 10)
   (println "I ❤️Clojure")
   ([{} () []]))
-( comment 
+( comment
   foo)
 (comment foo (comment bar))
 (foo (comment ({["(comment)"]})) ([{"(comment)"}]))

--- a/extras/test.clj
+++ b/extras/test.clj
@@ -65,3 +65,24 @@ foo(comment)bar
   foo)
 (comment foo (comment bar))
 (foo (comment ({["(comment)"]})) ([{"(comment)"}]))
+
+#_foo bar
+#_ foo bar
+#_,foo,bar
+#_
+foo bar
+#_
+foo
+bar
+#_(:bar [#{foo}])
+([{#_"foo"}])
+[:a
+ #_
+ [:b
+  [:c {:d :e}]]
+ [:b
+  [:c {:d :e}]]]
+(comment 
+  (foo #_"bar" baz))
+#_{:foo "foo"
+   :bar (comment [["bar"]])}

--- a/extras/test.clj
+++ b/extras/test.clj
@@ -44,6 +44,8 @@
 "(comment foo)"
 foo(comment)bar
 ( comment )
+(
+ comment "[foo]")
 (comment
   (Math/abs -1)
   (range 10)

--- a/extras/test.clj
+++ b/extras/test.clj
@@ -34,3 +34,22 @@
     #_( )
 )
 
+(comment
+  (comment (foo bar)))
+{:foo (comment (fn [x]
+                 (let [foo :bar])
+                 (str foo)))}
+[comment]
+(foo) comment (bar)
+"(comment foo)"
+foo(comment)bar
+( comment )
+(comment
+  (Math/abs -1)
+  (range 10)
+  (println "I ❤️Clojure")
+  ([{} () []]))
+( comment 
+  foo)
+(comment foo (comment bar))
+(foo (comment ({["(comment)"]})) ([{"(comment)"}]))

--- a/package.json
+++ b/package.json
@@ -83,10 +83,12 @@
 				},
 				"clojureWarrior.commentFormStyle": {
 					"type": "object",
-					"default": {
-						"textDecoration": "none; opacity: 0.5"
-					},
 					"description": "Style of `(comment)` forms",
+					"scope": "resource"
+				},
+				"clojureWarrior.ignoreStyle": {
+					"type": "object",
+					"description": "Style of `#_` ignored forms",
 					"scope": "resource"
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -80,6 +80,12 @@
 					"default": null,
 					"description": "Style of pair bracket highlight",
 					"scope": "resource"
+				},
+				"clojureWarrior.commentFormStyle": {
+					"type": "string",
+					"default": "dimmed",
+					"enum": ["dimmed", "italics", "comment"],
+					"scope": "resource"
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -83,11 +83,13 @@
 				},
 				"clojureWarrior.commentFormStyle": {
 					"type": "object",
+					"default": {"textDecoration": "none; opacity: 0.5"},
 					"description": "Style of `(comment)` forms",
 					"scope": "resource"
 				},
-				"clojureWarrior.ignoreStyle": {
+				"clojureWarrior.ignoredFormStyle": {
 					"type": "object",
+					"default": {"textDecoration": "none; opacity: 0.5"},
 					"description": "Style of `#_` ignored forms",
 					"scope": "resource"
 				}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "clojure-warrior",
 	"displayName": "Clojure Warrior",
 	"description": "Extension for Clojure development",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"publisher": "tonsky",
 	"license": "MIT",
 	"maintainers": [

--- a/package.json
+++ b/package.json
@@ -82,9 +82,11 @@
 					"scope": "resource"
 				},
 				"clojureWarrior.commentFormStyle": {
-					"type": "string",
-					"default": "dimmed",
-					"enum": ["dimmed", "italics", "comment"],
+					"type": "object",
+					"default": {
+						"textDecoration": "none; opacity: 0.5"
+					},
+					"description": "Style of `(comment)` forms",
 					"scope": "resource"
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
   const regexp = new RegExp("(" + "\\bcomment\\b|" + tokens.map(t => t.replace(/[\\()\[\]{}?]/g, "\\$&")).join("|") + ")", "g"),
   commentFormStyles = {"dimmed": {textDecoration: "none; opacity: 0.5"},
                        "italics": {fontStyle: "italic"},
-                       "comment": new vscode.ThemeColor("comment")};
+                       "comment": {color: new vscode.ThemeColor("editorLineNumber.foreground")}};
   function position_str(pos: Position) { return "" + pos.line + ":" + pos.character; }
   function is_clojure(editor) { return !!editor && editor.document.languageId === "clojure"; }
 
@@ -203,7 +203,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (opening[char]) {
           const len = char.length,
             pos = activeEditor.document.positionAt(match.index);
-          if (colorsEnabled) {
+          if (colorsEnabled && !(commentFormStyle === "comment" && in_comment_form)) {
             const decoration = { range: new Range(pos, pos.translate(0, len)) };
             rainbow[colorIndex(stack_depth)].push(decoration);
           }
@@ -233,7 +233,7 @@ export function activate(context: vscode.ExtensionContext) {
             for (let i = 0; i < pair.char.length; ++i)
               pairsForward.set(position_str(pair.pos.translate(0, i)), [opening, closing]);
             --stack_depth;
-            if (colorsEnabled) rainbow[colorIndex(stack_depth)].push(decoration);
+            if (colorsEnabled && !(commentFormStyle === "comment" && in_comment_form)) rainbow[colorIndex(stack_depth)].push(decoration);
           }
           continue;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,10 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
     pairings[o+c] = true;
     tokens.push(o, c);
   });
-  const regexp = new RegExp("(" + "\\bcomment\\b|" + tokens.map(t => t.replace(/[\\()\[\]{}?]/g, "\\$&")).join("|") + ")", "g"),
-  commentFormStyles = {"dimmed": {textDecoration: "none; opacity: 0.5"},
-                       "italics": {fontStyle: "italic"},
-                       "comment": {color: new vscode.ThemeColor("editorLineNumber.foreground")}};
+  const regexp = new RegExp("(" + "\\bcomment\\b|" + tokens.map(t => t.replace(/[\\()\[\]{}?]/g, "\\$&")).join("|") + ")", "g");
   function position_str(pos: Position) { return "" + pos.line + ":" + pos.character; }
   function is_clojure(editor) { return !!editor && editor.document.languageId === "clojure"; }
 
@@ -37,7 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
       configuration: vscode.WorkspaceConfiguration,
       rainbowColors,
       rainbowTypes:  vscode.TextEditorDecorationType[],
-      commentFormStyle: "dimmed" | "italics" | "comment",
+      commentFormStyle,
       commentFormType: vscode.TextEditorDecorationType,
       cycleBracketColors,
       misplacedBracketStyle,
@@ -104,7 +101,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     if(!!commentFormType)
       activeEditor.setDecorations(commentFormType, []);
-    commentFormType = decorationType(commentFormStyles[commentFormStyle]);
+    commentFormType = decorationType(commentFormStyle);
 
     dirty = false;
   }
@@ -203,7 +200,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (opening[char]) {
           const len = char.length,
             pos = activeEditor.document.positionAt(match.index);
-          if (colorsEnabled && !(commentFormStyle === "comment" && in_comment_form)) {
+          if (colorsEnabled) {
             const decoration = { range: new Range(pos, pos.translate(0, len)) };
             rainbow[colorIndex(stack_depth)].push(decoration);
           }
@@ -233,7 +230,7 @@ export function activate(context: vscode.ExtensionContext) {
             for (let i = 0; i < pair.char.length; ++i)
               pairsForward.set(position_str(pair.pos.translate(0, i)), [opening, closing]);
             --stack_depth;
-            if (colorsEnabled && !(commentFormStyle === "comment" && in_comment_form)) rainbow[colorIndex(stack_depth)].push(decoration);
+            if (colorsEnabled) rainbow[colorIndex(stack_depth)].push(decoration);
           }
           continue;
         }


### PR DESCRIPTION
Amend the decorator with awareness for `(comment)` forms. The styling of such forms is configurable by the user using these three options:

1. `"dimmed"`: (default), renders the form with 50% opacity, with intact syntax highlight.
2. `"italics"`: renders the form in italics, with intact syntax highlight.
3. `"comment"`: (not working yet), renders the form with the same styling as regular `;; comments`.

I am not sure how to do the `"comment"` option, or if it's even possible.

Please ignore the `#_` token handling for now, it is not implemented (and I do not have a good idea about how to implement it).

I think I got the `(comment)` parsing right, but I tried a few other ways too, and would like feedback. (Well, feedback in general too, but the crucial part seems to be the parsing.)

Cheers! 🍻 